### PR TITLE
Make tab content open on the side rather than below

### DIFF
--- a/lib/_sidebar.erb
+++ b/lib/_sidebar.erb
@@ -1,6 +1,6 @@
     <!-- Sidebar -->
     <div class="container">
-      <div class="col-sm-2">
+      <div class="col-sm-2 sidebar">
         <nav class="nav-sidebar">
           <ul class="nav tabs">
             <%- @site_map['docs'].each do |key, value| -%>
@@ -20,7 +20,7 @@
         </nav>
       </div>
       <!-- Tab content -->
-      <div class="tab-content">
+      <div class="tab-content content">
       <%- @site_map['docs'].each do |key, value| -%>
         <%- first_entry = true -%>
         <%- value.each do |key2| -%>

--- a/lib/css/gluegun.css
+++ b/lib/css/gluegun.css
@@ -1,0 +1,14 @@
+.content {
+    width: calc(83.333333% - 5px);
+    display: inline-block;
+    vertical-align: top;
+}
+
+.sidebar {
+    display: inline-block;
+}
+
+img {
+    max-width:100%;
+    max-height:100%;
+}

--- a/lib/index.erb
+++ b/lib/index.erb
@@ -20,6 +20,7 @@
       });
     </script>
     <link href="css/bootstrap.css" rel="stylesheet">
+    <link href="css/gluegun.css" rel="stylesheet">
     <script src="js/bootstrap.js"></script>
   </head>
   <body>


### PR DESCRIPTION
This commit also fixes the issue where the tab content images were
overflowing from the container

Fixes #16