### PR TITLE
Handle broken links in yml file

### DIFF
--- a/lib/_sidebar.erb
+++ b/lib/_sidebar.erb
@@ -14,14 +14,16 @@
                       <%- else -%>
                         <%- active_keyword="" -%>
                       <%- end -%>
-                      <li>
-                        <%- if !key2["Slug"] -%>
-                          <%- key2["Slug"] = get_slug(key2) -%>
-                        <%- end -%>
-                        <a class="<%=active_keyword%>" href="#<%=key2["Slug"]%>" data-toggle="tab">
-                          <%=key2.keys[0]%>
-                        </a>
-                      </li>
+                      <%- if reveal(raw(key2["Link"])) -%>
+                        <li>
+                          <%- if !key2["Slug"] -%>
+                            <%- key2["Slug"] = get_slug(key2) -%>
+                          <%- end -%>
+                          <a class="<%=active_keyword%>" href="#<%=key2["Slug"]%>" data-toggle="tab">
+                            <%= key2.keys[0] -%>
+                          </a>
+                        </li>
+                      <%- end -%>
                 <%- end -%>
               <%- end -%>
             <%- end -%>

--- a/lib/gluegun.rb
+++ b/lib/gluegun.rb
@@ -38,12 +38,18 @@ module Gluegun
       @site_map['Documents'].each do |categories|
          categories.each do |key, value|
           value.each do |key2|
+            orig_link = key2["Link"].dup
             link = raw(key2['Link'])
             if !key2["Slug"]
               key2["Slug"] = get_slug(key2)
             end
-            File.open(File.join(dest_path,"/#{key2["Slug"]}.html"), "w+") do |f|
-              f.puts(GitHub::Markdown.render_gfm(open(link).read))
+            begin
+              File.open(File.join(dest_path,"/#{key2["Slug"]}.html"), "w+") do |f|
+                f.puts(GitHub::Markdown.render_gfm(open(link).read))
+              end
+            rescue OpenURI::HTTPError
+              puts "WARNING:  " + key + " -> " + key2.keys[0] + ": Page not found, the " + 
+                   "corresponding link will not be displayed on the sidebar. (" + orig_link + ")"
             end
           end
         end
@@ -55,7 +61,11 @@ module Gluegun
     end
 
     def self.reveal(link)
-      return GitHub::Markdown.render_gfm(open(link).read)
+      begin
+        response = GitHub::Markdown.render_gfm(open(link).read)
+        return response
+      rescue OpenURI::HTTPError
+      end
     end
 
     private

--- a/site.yml
+++ b/site.yml
@@ -12,6 +12,9 @@ Documents:
         Link: https://github.com/minio/minio/blob/master/docs/gateway/README.md
 
   - Minio Client: 
+      - Minio Client Quick Start Guide: 
+        Link: https://github.com/minio/minio/blob/master/docs/minio-limitations.md
+
       - Minio Client Complete Guide: 
         Link: https://github.com/minio/minio/blob/master/docs/FreeBSD.md
   
@@ -23,6 +26,8 @@ Documents:
         Link: https://github.com/minio/minio/blob/master/docs/shared-backend/README.md
 
   - Minio Cookbook:
+      - Minio Limitations:
+        Link: https://github.com/minio/minio/blob/master/docs/minio-limitations.md
+
       - Minio FreeBSD Quickstart Guide:
         Link: https://github.com/minio/minio/blob/master/docs/FreeBSD.md
-        Slug: minio-freebsd-quickstart-guide


### PR DESCRIPTION
This commit handles the case where a link is broken in the yml file by
printing a warning message and not displaying the corresponding link on
the sidebar.
Fixes #33