### PR TITLE
Add Google Analytics to Gluegun by setting the token on the .yml file

### DIFF
--- a/lib/_footer.erb
+++ b/lib/_footer.erb
@@ -1,5 +1,15 @@
     <footer id="footer" class="text-center">
       Gluegun project is licensed under Apache 2.0 License.
+      <%- if @site_map["Tokens"] && @site_map["Tokens"].key?("Google Analytics") -%>
+        <script>
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+          ga('create', '<%= @site_map["Tokens"]["Google Analytics"] %>', 'auto');
+          ga('send', 'pageview');
+        </script>
+      <%- end -%>
     </footer>
   </body>
 </html>

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,7 @@
 Site: "Minio Docs"
 Output: "docs"
+Tokens:
+  Google Analytics: "UA-XXXXX-Y"
 Documents:  
   - Minio Server: 
       - Minio Server Quick Start Guide: 


### PR DESCRIPTION
Part of #30