### PR TITLE
Add pattern filter to yml and check for valid links w/o opening files

### DIFF
--- a/lib/_sidebar-template.erb
+++ b/lib/_sidebar-template.erb
@@ -28,7 +28,7 @@
                                 </a>
                                 <ul class="doc-link__items" style='<%= "<%= active_keywords[1] -\%\>" -%>'>
                                     <%- value.each do |value2| -%>
-                                        <%- if !value2["Link"].nil? && reveal(raw(value2["Link"])) -%>
+                                        <%- if !value2["Link"].nil? && is_url_valid(raw(value2["Link"])) -%>
                                                 <li>
                                                     <%- if !value2["Slug"] -%>
                                                         <%- value2["Slug"] = get_slug(value2) -%>

--- a/site-example.yml
+++ b/site-example.yml
@@ -20,6 +20,8 @@ Documents:                                                              # Requir
         Link: github link to the raw md file                            # Required - Document Link     
         Slug: document-title                                            # Optional - Document Slug
 
+Exclude Patterns:                                                       # Optional - Pattern to be filtered out from the fetched markdown
+  - Enter regex here
 
 # Full Example Shown Below
 
@@ -72,3 +74,6 @@ Documents:                                                              # Requir
 
 #       - Minio FreeBSD Quickstart Guide:
 #         Link: https://github.com/minio/minio/blob/master/docs/FreeBSD.md
+
+# Exclude Patterns:                                                     # Optional - Pattern to be filtered out from the fetched markdown
+#   - s?\[\!\[Slack\].*$??

--- a/site.yml
+++ b/site.yml
@@ -26,3 +26,7 @@ Documents:
       - Gluegun Theming Guide:
         Link: https://github.com/minio/gluegun/blob/master/README.md
         Slug: gluegun-theming-guide
+
+Exclude Patterns:
+  - s?\[\!\[Slack\].*$??
+  - s?\[\!\[Gitter\].*$??


### PR DESCRIPTION
- This commit adds an Exclude Patterns field to the .yml file to filter
out unwanted patterns from the markdown content fetched from Github.
- This commit also checks if the links are valid or not without opening
the file. This change was done to improve performance by preventing the
'reveal' method from running for each document while the sidebar is
being generated.