### PR TITLE
Add pattern filter to yml and check for valid links w/o opening files

### DIFF
--- a/lib/_sidebar-template.erb
+++ b/lib/_sidebar-template.erb
@@ -28,7 +28,7 @@
                                 </a>
                                 <ul class="doc-link__items" style='<%= "<%= active_keywords[1] -\%\>" -%>'>
                                     <%- value.each do |value2| -%>
-                                        <%- if !value2["Link"].nil? && reveal(raw(value2["Link"])) -%>
+                                        <%- if !value2["Link"].nil? && is_link_valid(raw(value2["Link"])) -%>
                                                 <li>
                                                     <%- if !value2["Slug"] -%>
                                                         <%- value2["Slug"] = get_slug(value2) -%>

--- a/site-example.yml
+++ b/site-example.yml
@@ -14,6 +14,10 @@ Plugins:                                                                # Option
       index: "INDEX_NAME"
   - Google Analytics: "UA-XXXXX-Y"
 
+Rules:                                                                  # Optional - Regex rules
+  Filter:                                                               # Pattern to be filtered out from the fetched markdown
+    - Enter regex here
+
 Documents:                                                              # Required - Documents with links to generate site
   - Category Heading:                                                   # Required- Category Name
       - Document Title:                                                 # Required - Document Title
@@ -36,6 +40,13 @@ Documents:                                                              # Requir
 #       apiKey: "xxxxxxxxxxxxxxxx"
 #       index: "xxxxxxxx"
 #   - Google Analytics: "UA-xxxxxxx-Y"
+
+# Rules:                                                                # Optional - Regex rules
+#   Filter:                                                             # Pattern to be filtered out from the fetched markdown
+#     - s?\[\!\[Slack\].*$??
+#     - s?\[\!\[Gitter\].*$??
+#   Replace:
+#     - minio MINIO
 
 # Documents:                                                            # Required - Documents with links to generate site
 #   - Minio Server:                                                     # Required- Category Name

--- a/site.yml
+++ b/site.yml
@@ -16,6 +16,11 @@ Plugins:
       Label: "Talk to community"
       Link: "/"
 
+Rules:
+  Filter:
+    - s?\[\!\[Slack\].*$??
+    - s?\[\!\[Gitter\].*$??
+
 Documents:
   - Get Started:
       - Gluegun Quick Start Guide:


### PR DESCRIPTION
- This commit adds a Rules field to the .yml file, and a Filter field
under it to exclude unwanted patterns from the markdown content
fetched from Github.
- This commit also checks if the links are valid or not without opening
the file. This change was done to improve performance by preventing the
'reveal' method from running for each document while the sidebar is
being generated.
- When the first link in the list of Documents is broken, to avoid the
wrong link to be highlighted on index.html, Gluegun now returns an error
while generating the index page and asks the user to correct it.