### PR TITLE
Add support for topics that render but don't appear on sidebar

### DIFF
--- a/lib/_sidebar-template.erb
+++ b/lib/_sidebar-template.erb
@@ -17,13 +17,19 @@
                         <%- heading.each do |key, value| -%>
                             <%= "<%- active_keywords = ['', ''] -\%\>" -%>
 
-                            <%= "<%- if defined?(categories) && categories.keys[0] ==='" + key + "'-\%\>" -%>
+                            <%= "<%- if !defined?(key2) && first_link -\%\>" -%>
 
                                 <%= "<%- active_keywords = ['toggled', 'display: block'] -\%\>" -%>
 
-                            <%= "<%- elsif !defined?(key2) && first_link -\%\>" -%>
+                            <%= "<%- end -\%\>" -%>
 
-                                <%= "<%- active_keywords = ['toggled', 'display: block'] -\%\>" -%>
+                            <%= "<%- if defined?(key2) && key2['Options'] != 'hidden' -\%\>" -%>
+
+                                <%= "<%- if defined?(categories) && categories.keys[0] ==='" + key + "'-\%\>" -%>
+
+                                    <%= "<%- active_keywords = ['toggled', 'display: block'] -\%\>" -%>
+
+                                <%= "<%- end -\%\>" -%>
 
                             <%= "<%- end -\%\>" -%>
 
@@ -33,7 +39,7 @@
                                     </a>
                                     <ul class="doc-link__items" style='<%= "<%= active_keywords[1] -\%\>" -%>'>
                                         <%- value.each do |value2| -%>
-                                            <%- if !value2["Link"].nil? && reveal(raw(value2["Link"])) -%>
+                                            <%- if value2["Options"] != "hidden" && !value2["Link"].nil? && reveal(raw(value2["Link"])) -%>
                                                     <li>
                                                         <%- if !value2["Slug"] -%>
                                                             <%- value2["Slug"] = get_slug(value2) -%>

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 Site: "Gluegun"
 Output: "docs"
-Logo: "https://minio.io/img/logo/wordmark_white.svg"
+Logo: "https://minio.io/img/logo/wordmark_black.svg"
 
 Language:
   - Chinese: https://gluegun.minio.io/cn
@@ -26,3 +26,8 @@ Documents:
       - Gluegun Theming Guide:
         Link: https://github.com/minio/gluegun/blob/master/README.md
         Slug: gluegun-theming-guide
+
+      - Gluegun Internal Page:
+        Link: https://github.com/minio/gluegun/blob/master/README.md
+        Slug: gluegun-internal-page
+        Options: hidden


### PR DESCRIPTION
A topic that is rendered but not displayed on the sidebar can now be
created by adding the 'Options: hidden' line under the individual file
objects in the .yml file as follows:

- Gluegun Internal Page:
  Link: https://github.com/minio/gluegun/blob/master/README.md
  Slug: gluegun-internal-page
  Options: hidden

This commit also adds this file to the yml file to demonstrate this
option, and changes the wordmark color from white to black to comply
with the sidebar styling changes.

Fixes miniohq/gluegun#30