### PR TITLE
Replace old logo & add logo width as an adjustable option

### DIFF
--- a/lib/scss/inc/_aside.scss
+++ b/lib/scss/inc/_aside.scss
@@ -80,7 +80,7 @@
   margin-bottom: 30px;
 
   & > img {
-    max-width:80px;
+    max-width: $logo-max-width;
   }
 }
 

--- a/lib/scss/inc/_variables.scss
+++ b/lib/scss/inc/_variables.scss
@@ -68,6 +68,9 @@ $doclink-toggle-icon-stroke: $white !default;
 $header-bg: $white !default;
 $header-height: 90px !default;
 
+// Logo
+$logo-max-width: 120px !default;
+
 // Code
 $pre-bg: #f4f4f4 !default;
 $code-color: $body-color !default;

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 Site: "Gluegun"
 Output: "docs"
-Logo: "https://minio.io/img/logo/wordmark_black.svg"
+Logo: "https://min.io/resources/img/logo/black-logo.svg"
 
 Language:
   - Chinese: https://gluegun.minio.io/cn


### PR DESCRIPTION
The users can now adjust the max-width attribute of the logo on the
theme variables file (lib/scss/theme/_variables.scss) by providing a
value for -max-width