### PR TITLE
Add HubSpot plugin and add empty value check for plugins

### DIFF
--- a/lib/_footer.erb
+++ b/lib/_footer.erb
@@ -22,7 +22,7 @@
 
     <%- if !@site_map['Plugins'].nil? -%>
       <%- @site_map['Plugins'].each do |categories| -%>
-        <%- if categories.key?("Google Analytics") -%>
+        <%- if categories.key?("Google Analytics") && !categories["Google Analytics"].nil? -%>
           <!-- Google Analytics -->
           <script>
             (function (i, s, o, g, r, a, m) {
@@ -39,7 +39,7 @@
             ga ('create', '<%= categories["Google Analytics"] %>', 'auto');
             ga ('send', 'pageview');
           </script>
-        <%- elsif categories.key?("Mixpanel") -%>
+        <%- elsif categories.key?("Mixpanel") && !categories["Mixpanel"].nil? -%>
           <!-- Mixpanel -->
           <script type="text/javascript">
             (function(e, a) {
@@ -104,6 +104,9 @@
               });
             </script>
           <%- end -%>
+        <%- elsif categories.key?("HubSpot") && !categories["HubSpot"].nil? -%>
+          <!-- HubSpot -->
+          <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/<%= categories["HubSpot"] %>.js"></script>
         <%- end -%>
       <%- end -%>
     <%- end -%>

--- a/site.yml
+++ b/site.yml
@@ -15,6 +15,7 @@ Plugins:
       index: "INDEX_NAME"
   - Google Analytics: "UA-XXXXX-Y"
   - Mixpanel: "MIXPANEL_TOKEN"
+  - HubSpot: "HUBSPOT_TOKEN"
   - Footer Widget:
       Label: "Talk to community"
       Link: "/"


### PR DESCRIPTION
This commit adds HubSpot plugin compability and fixes the issue where
empty values were being inserted in the scripts for the GA and Mixpanel
plugins when a key name was specified for a plugin on the .yml file
without any value specified.